### PR TITLE
feat : integrate attendance and leave Sanity backend with the UI

### DIFF
--- a/frontend/app/api/attendance/[id]/route.ts
+++ b/frontend/app/api/attendance/[id]/route.ts
@@ -1,0 +1,12 @@
+import { deleteAttendance } from "@/lib/sanity/utils/attendance";
+import { NextRequest } from "next/server";
+
+export async function DELETE(
+  _: NextRequest,
+  context: { params: { id: string } }
+) {
+  const { params } = await context;
+  const { id } = await params;
+  await deleteAttendance(id);
+  return new Response("Attendance deleted successfully", { status: 200 });
+}

--- a/frontend/app/api/attendance/route.ts
+++ b/frontend/app/api/attendance/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAttendance } from "@/lib/sanity/utils/attendance";
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+  const attendance = await createAttendance(data);
+  return NextResponse.json(attendance);
+}

--- a/frontend/app/api/department/route.ts
+++ b/frontend/app/api/department/route.ts
@@ -1,0 +1,22 @@
+const { createDepartment, getAllDepartments } = await import(
+  "@/lib/sanity/utils/department"
+);
+
+export async function GET() {
+  try {
+    const departments = await getAllDepartments();
+    return new Response(JSON.stringify(departments), { status: 200 });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error }), { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  try {
+    const leave = await createDepartment(data);
+    return new Response(JSON.stringify(leave), { status: 201 });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error }), { status: 500 });
+  }
+}

--- a/frontend/app/api/leaves/[id]/route.ts
+++ b/frontend/app/api/leaves/[id]/route.ts
@@ -1,0 +1,12 @@
+import { deleteLeave } from "@/lib/sanity/utils/leaves";
+import { NextRequest } from "next/server";
+
+export async function DELETE(
+  _: NextRequest,
+  context: { params: { id: string } } | Promise<{ params: { id: string } }>
+) {
+  const { params } = await context;
+  const { id } = await params;
+  await deleteLeave(id);
+  return new Response("Leave deleted successfully", { status: 200 });
+}

--- a/frontend/app/api/leaves/route.ts
+++ b/frontend/app/api/leaves/route.ts
@@ -1,0 +1,20 @@
+const { createLeave, getAllLeaves } = await import("@/lib/sanity/utils/leaves");
+
+export async function GET() {
+  try {
+    const leaves = await getAllLeaves();
+    return new Response(JSON.stringify(leaves), { status: 200 });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error }), { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  try {
+    const leave = await createLeave(data);
+    return new Response(JSON.stringify(leave), { status: 201 });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error }), { status: 500 });
+  }
+}

--- a/frontend/app/api/role/[id]/route.ts
+++ b/frontend/app/api/role/[id]/route.ts
@@ -1,0 +1,12 @@
+import { deleteRole } from "@/lib/sanity/utils/role";
+import { NextRequest } from "next/server";
+
+export async function DELETE(
+  _: NextRequest,
+  context: { params: { id: string } } | Promise<{ params: { id: string } }>
+) {
+    const { params } = await context;
+    const { id } = await params;
+  await deleteRole(id);
+  return new Response("Leave deleted successfully", { status: 200 });
+}

--- a/frontend/app/api/role/route.ts
+++ b/frontend/app/api/role/route.ts
@@ -1,0 +1,25 @@
+import { createRole, getAllRoles } from "@/lib/sanity/utils/role";
+
+export async function GET() {
+  try {
+    const roles = await getAllRoles();
+    return new Response(JSON.stringify(roles), { status: 200 });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error }), { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  const data = await req.json();
+
+  try {
+    const leave = await createRole(data);
+    return new Response(JSON.stringify(leave), {
+      status: 201,
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error }), {
+      status: 500,
+    });
+  }
+}

--- a/frontend/app/attendance/page.tsx
+++ b/frontend/app/attendance/page.tsx
@@ -1,21 +1,67 @@
-import { getAttendances } from '@/lib/sanity/utils/attendance';
-import React from 'react'
+"use client";
 
-const page = async() => {
-  const attendances = await getAttendances();
-  console.log(attendances,"djsj");
+import {
+  getAttendances,
+  createAttendance,
+  deleteAttendance,
+} from "@/lib/sanity/utils/attendance";
+import React, { useEffect, useState } from "react";
+
+const Page = () => {
+  const [attendances, setAttendances] = useState<any[]>([]);
+
+  useEffect(() => {
+    async function fetchData() {
+      const data = await getAttendances();
+      setAttendances(data);
+    }
+    fetchData();
+  }, []);
+
+  async function handleCreate() {
+    const res = await fetch("/api/attendance", {
+      method: "POST",
+      body: JSON.stringify({
+        employeeId: "4a94372b-cf18-409b-a3b9-7e9bba255fd1",
+        date: new Date().toISOString().split("T")[0], // Current date in YYYY-MM-DD format
+        checkIn: "2025-06-12 09:00",
+        checkOut: "2025-06-12 17:00",
+      }),
+    });
+    const newAttendance = await res.json();
+    setAttendances([...attendances, newAttendance]);
+  }
+
+  async function handleDelete(id: string) {
+    await fetch(`/api/attendance/${id}`, { method: "DELETE" });
+    setAttendances(attendances.filter((att) => att._id !== id));
+  }
+
   return (
-    <div>{attendances.map((attendance) => (
-      <div key={attendance._id}>
-        <h2>{attendance.employee.name}</h2>
-        <p>Date: {new Date(attendance.date).toLocaleDateString()}</p>
-        <p>Check In: {attendance.checkIn}</p>
-        <p>Check Out: {attendance.checkOut}</p>
-        <p>Created At: {attendance._createdAt}</p>
+    <div>
+      <button
+        onClick={handleCreate}
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        Create Test Attendance
+      </button>
+      {attendances.map((attendance) => (
+        <div key={attendance._id} className="border p-4 my-2">
+          <h2>{attendance.employee.name}</h2>
+          <p>Date: {new Date(attendance.date).toLocaleDateString()}</p>
+          <p>Check In: {attendance.checkIn}</p>
+          <p>Check Out: {attendance.checkOut}</p>
+          <p>Created At: {attendance._createdAt}</p>
+          <button
+            onClick={() => handleDelete(attendance._id)}
+            className="text-red-600 mt-2"
+          >
+            Delete
+          </button>
         </div>
-    ))}
-      </div>
-  )
-}
+      ))}
+    </div>
+  );
+};
 
-export default page
+export default Page;

--- a/frontend/app/employees/page.tsx
+++ b/frontend/app/employees/page.tsx
@@ -1,21 +1,146 @@
-import React from 'react'
-import { getEmployees } from '@/lib/sanity/utils/employee'
+import {
+  createEmployee,
+  deleteEmployee,
+  getEmployees,
+} from "@/lib/sanity/utils/employee";
+import { getAllRoles } from "@/lib/sanity/utils/role";
+import { getAllDepartments } from "@/lib/sanity/utils/department";
 
-const page = async() => {
-    const employees = await getEmployees();
-  
+const EmployeesPage = async () => {
+  const employees = await getEmployees();
+  const roles = await getAllRoles();
+  const departments = await getAllDepartments();
+
   return (
-    <div>
-      {employees.map((employee) => (
-        <div key={employee._id}>
-          {employee.name}
-          <p>{employee.role.title}</p>
-          <p>{employee.departmentName}</p>
-          <p>{employee.startDate}</p>
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-6">Employee Management</h1>
+
+      {/* Create Employee Form */}
+      <div className="bg-white p-4 rounded-lg shadow mb-6">
+        <h2 className="text-xl font-semibold mb-4">Add New Employee</h2>
+        <form
+          action={async (formData: FormData) => {
+            "use server";
+
+            const departmentId = formData.get("departmentId") as string;
+            const roleId = formData.get("roleId") as string;
+
+            const newEmployee = {
+              name: formData.get("name") as string,
+              email: formData.get("email") as string,
+              phone: formData.get("phone") as string,
+
+              employmentStatus: "active",
+              roleId,
+              departmentId,
+              startDate: new Date().toISOString().slice(0, 10),
+              documents: [],
+            };
+
+            await createEmployee(newEmployee);
+          }}
+          className="space-y-4"
+        >
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Name
+            </label>
+            <input type="text" name="name" required className="input-style" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Email
+            </label>
+            <input type="email" name="email" required className="input-style" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Phone
+            </label>
+            <input type="tel" name="phone" required className="input-style" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Role
+            </label>
+            <select name="roleId" required className="input-style">
+              <option value="">Select a role</option>
+              {roles.map((role) => (
+                <option key={role._id} value={role._id}>
+                  {role.title}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Department
+            </label>
+            <select name="departmentId" required className="input-style">
+              <option value="">Select a department</option>
+              {departments.map((dept) => (
+                <option key={dept._id} value={dept._id}>
+                  {dept.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            type="submit"
+            className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+          >
+            Add Employee
+          </button>
+        </form>
+      </div>
+
+      {/* Employee List */}
+      <div className="bg-white rounded-lg shadow">
+        <h2 className="text-xl font-semibold p-4 border-b">Employees List</h2>
+        <div className="divide-y">
+          {employees.map((employee) => (
+            <div
+              key={employee._id}
+              className="p-4 flex justify-between items-center"
+            >
+              <div>
+                <h3 className="font-medium">{employee.name}</h3>
+                <p className="text-sm text-gray-600">{employee.email}</p>
+                <p className="text-sm text-gray-600">{employee.phone}</p>
+                <p className="text-sm text-gray-600">
+                  Role: {employee.role?.title}
+                </p>
+                <p className="text-sm text-gray-600">
+                  Department: {employee.department?.name}
+                </p>
+              </div>
+              <div>
+                <form
+                  action={async (formData: FormData) => {
+                    "use server";
+                    const id = formData.get("id") as string;
+                    await deleteEmployee(id);
+                  }}
+                >
+                  <input type="hidden" name="id" value={employee._id} />
+                  <button
+                    type="submit"
+                    className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
+                  >
+                    Delete
+                  </button>
+                </form>
+              </div>
+            </div>
+          ))}
         </div>
-      ))}
+      </div>
     </div>
   );
-}
+};
 
-export default page
+export default EmployeesPage;
+
+// Styling shortcut
+const inputStyle =
+  "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500";

--- a/frontend/app/leaves/page.tsx
+++ b/frontend/app/leaves/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+import { Leave } from "@/types/leaves";
+import React, { useEffect, useState } from "react";
+
+export default function LeavesPage() {
+  const [leaves, setLeaves] = useState<Leave[]>([]);
+
+  // Fetch leaves on mount
+  useEffect(() => {
+    fetch("/api/leaves")
+      .then((res) => res.json())
+      .then(setLeaves);
+  }, []);
+
+  // Create a test leave
+  async function handleCreate() {
+    const res = await fetch("/api/leaves", {
+      method: "POST",
+      body: JSON.stringify({
+        type: "Vacation",
+        status: "Pending",
+        employeeId: "4a94372b-cf18-409b-a3b9-7e9bba255fd1",
+        startDate: "2025-06-15",
+        endDate: "2025-06-18",
+        reason: "Vacation",
+      }),
+    });
+    const newLeave = await res.json();
+    setLeaves([...leaves, newLeave]);
+  }
+
+  // Delete a leave
+  async function handleDelete(id: string) {
+    await fetch(`/api/leaves/${id}`, { method: "DELETE" });
+    setLeaves(leaves.filter((leave) => leave._id !== id));
+  }
+
+  return (
+    <div>
+      <h1>Leaves</h1>
+      <button
+        onClick={handleCreate}
+        className="bg-blue-500 text-white px-4 py-2 rounded mb-4"
+      >
+        Create Test Leave
+      </button>
+      <ul>
+        {leaves.map((leave) => (
+          <li
+            key={leave._id}
+            className="border p-2 mb-2 flex justify-between items-center"
+          >
+            <span>
+              {leave.employee?.name || "Unknown"}: {leave.startDate} to{" "}
+              {leave.endDate} ({leave.reason})
+            </span>
+            <button
+              onClick={() => handleDelete(leave._id)}
+              className="bg-red-500 text-white px-2 py-1 rounded"
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/lib/sanity/client.ts
+++ b/frontend/lib/sanity/client.ts
@@ -4,4 +4,6 @@ export const client = createClient({
   projectId: "rkkcgp3r",
   dataset: "production",
   apiVersion: "2025-12-06",
+  useCdn: false,
+  token: process.env.SANITY_API_TOKEN, // Ensure this is set in your environment variables
 });

--- a/frontend/lib/sanity/schemas/index.ts
+++ b/frontend/lib/sanity/schemas/index.ts
@@ -4,6 +4,7 @@ import attendance from "./attendance";
 import schedule from "./schedule";
 import department from "./department";
 import role from "./role";
+import leave from "./leave";
 
 const schemas = [
   employee,
@@ -12,5 +13,6 @@ const schemas = [
   schedule,
   department,
   role,   
+  leave
 ];
 export default schemas;

--- a/frontend/lib/sanity/utils/attendance.ts
+++ b/frontend/lib/sanity/utils/attendance.ts
@@ -1,4 +1,4 @@
-import { Attendance } from "@/types/attendance";
+import { Attendance, AttendanceInput } from "@/types/attendance";
 import { groq } from "next-sanity";
 import { client } from "../client";
 
@@ -11,12 +11,69 @@ export async function getAttendances(): Promise<Attendance[]> {
       employee->{
         _id,
         name,
-        photo
+        email,
       },
       date,
-      checkInTime,
-      checkOutTime,
+      checkIn,
+      checkOut,
       
     }`
   );
+}
+
+export async function getAttendanceById(
+  id: string
+): Promise<Attendance | null> {
+  return client.fetch(
+    groq`*[_type == "attendance" && _id == $id][0]{
+      _id,
+      _createdAt,
+      _updatedAt,
+      employee->{
+        _id,
+        name,
+        email,
+      },
+      date,
+      checkIn,
+      checkOut,
+    }`,
+    { id }
+  );
+}
+
+export async function createAttendance(
+  attendance: AttendanceInput
+): Promise<Attendance | null> {
+  console.log("token",process.env.SANITY_API_TOKEN)
+  const newDoc = await client.create({
+    _type: "attendance",
+    employee: { _type: "reference", _ref: attendance.employeeId },
+    date: attendance.date,
+    checkIn: attendance.checkIn || null,
+    checkOut: attendance.checkOut || null,
+  });
+
+  // Fetch the populated attendance with expanded employee
+  return getAttendanceById(newDoc._id);
+}
+
+export async function updateAttendance(
+  id: string,
+  attendance: AttendanceInput
+): Promise<Attendance | null> {
+  const updatedDoc = await client.patch(id)
+    .set({
+      employee: { _type: "reference", _ref: attendance.employeeId },
+      date: attendance.date,
+      checkIn: attendance.checkIn || null,
+      checkOut: attendance.checkOut || null,
+    })
+    .commit();
+
+  // Fetch the populated attendance with expanded employee
+  return getAttendanceById(updatedDoc._id);
+}
+export async function deleteAttendance(id: string): Promise<void> {
+  await client.delete(id);
 }

--- a/frontend/lib/sanity/utils/department.ts
+++ b/frontend/lib/sanity/utils/department.ts
@@ -1,0 +1,53 @@
+import { Department } from "@/types/department";
+import { client } from "../client";
+
+export async function getAllDepartments(): Promise<Department[]> {
+  const query = `*[_type == "department"]{
+    _id,
+    _createdAt,
+    _updatedAt,
+    name,
+    description
+  } | order(name asc)`;
+
+  const results = await client.fetch(query);
+  return results as Department[];
+}
+export async function getDepartmentById(id: string): Promise<Department | null> {
+  const query = `*[_type == "department" && _id == $id][0]{
+    _id,
+    _createdAt,
+    _updatedAt,
+    name,
+    description
+  }`;
+
+  const department = await client.fetch(query, { id });
+  return department || null;
+}
+export async function createDepartment(department: Omit<Department, "_id" | "_createdAt" | "_updatedAt">): Promise<Department> {
+  const newDoc = await client.create({
+    _type: "department",
+    ...department,
+  });
+
+  const populated = await getDepartmentById(newDoc._id);
+  return populated as Department;
+}
+export async function updateDepartment(id: string, department: Partial<Omit<Department, "_id" | "_createdAt" | "_updatedAt">>): Promise<Department | null> {
+  const updatedDoc = await client.patch(id).set(department).commit();
+
+  if (!updatedDoc) return null;
+
+  const populated = await getDepartmentById(updatedDoc._id);
+  return populated as Department;
+}
+export async function deleteDepartment(id: string): Promise<{_id:string}| null> {
+  try {
+    const result = client.delete(id);
+    return result;
+  } catch (error) {
+    console.error("Error deleting department:", error);
+    return null;
+  }
+}

--- a/frontend/lib/sanity/utils/employee.ts
+++ b/frontend/lib/sanity/utils/employee.ts
@@ -1,4 +1,4 @@
-import { Employee } from "@/types/employee";
+import { Employee, EmployeeInput } from "@/types/employee";
 import { groq } from "next-sanity";
 import { client } from "../client";
 
@@ -18,8 +18,66 @@ export async function getEmployees(): Promise<Employee[]> {
     title
     },
     startDate,
-    "departmentName": department->name,
+    department->{name},
     "documents": documents[] 
     }`
   );
+}
+
+export async function getEmployeeById(id: string): Promise<Employee | null> {
+  const query = groq`*[_type == "employee" && _id == $id][0]{
+    _id,
+    _createdAt,
+    _updatedAt,
+    name,
+    email,
+    phone,
+    photo,
+    employmentStatus,
+    role->{
+      title
+    },
+    startDate,
+    "departmentName": department->name,
+    "documents": documents[] 
+  }`;
+
+  const employee = await client.fetch(query, { id });
+  return employee || null;
+}
+
+export async function createEmployee(employee:EmployeeInput): Promise<Employee> {
+  const newDoc = await client.create({
+    _type: "employee",
+    role: { _type:"reference",_ref: employee.roleId },
+    department: { _type: "reference", _ref: employee.departmentId },
+    name: employee.name,
+    email: employee.email,
+    phone: employee.phone,
+    photo: employee.photo,
+    employmentStatus: employee.employmentStatus,
+    startDate: employee.startDate,
+    documents: employee.documents || [],
+  });
+
+  const populated = await getEmployeeById(newDoc._id);
+  return populated as Employee;
+}
+
+export async function updateEmployee(id: string, employee: Partial<EmployeeInput>): Promise<Employee | null> {
+  const updatedDoc = await client.patch(id)
+    .set(employee)
+    .commit();
+  if (!updatedDoc) {
+    throw new Error(`Failed to update employee with id ${id}`);
+  }
+  const populated = await getEmployeeById(updatedDoc._id);
+  return populated as Employee;
+}
+export async function deleteEmployee(id: string): Promise<{ _id: string } | null> {
+  const result = await client.delete(id);
+  if (!result) {
+    throw new Error(`Failed to delete employee with id ${id}`);
+  }
+  return result;
 }

--- a/frontend/lib/sanity/utils/leaves.ts
+++ b/frontend/lib/sanity/utils/leaves.ts
@@ -1,0 +1,98 @@
+import { groq } from "next-sanity";
+import { client } from "../client";
+import { Leave, LeaveInput } from "@/types/leaves";
+
+
+export async function getAllLeaves(): Promise<Leave[]> {
+  return client.fetch(
+    groq`*[_type == "leave"]{
+      _id,
+      _createdAt,
+      _updatedAt,
+      employee->{
+        _id,
+        name,
+        email
+      },
+      type,
+      status,
+      startDate,
+      endDate,
+      reason
+    }`
+  );
+}
+
+export async function getLeaveById(id: string): Promise<Leave | null> {
+  const query = groq`*[_type == "leave" && _id == $id][0]{
+    _id,
+    _createdAt,
+    _updatedAt,
+    employee->{
+      _id,
+      name,
+      email
+    },
+    type,
+    status,
+    startDate,
+    endDate,
+    reason
+  }`;
+  const leave = await client.fetch(query, { id });
+  return leave || null;
+}
+
+export async function getLeaveByEmployeeId(
+  employeeId: string
+): Promise<Leave[]> {
+  return client.fetch(  
+    groq`*[_type == "leave" && employee._ref == $employeeId]{
+      _id,
+      _createdAt,
+      _updatedAt,
+      employee->{
+        _id,
+        name,
+        email
+      },
+      type,
+      status,
+      startDate,
+      endDate,
+      reason
+    }`,
+    { employeeId }
+  );
+}
+
+export async function createLeave(leave: LeaveInput): Promise<Leave> {
+  const newDoc = await client.create({
+    _type: "leave",
+    employee: { _type: "reference", _ref: leave.employeeId },
+    type: leave.type,
+    status: leave.status,
+    startDate: leave.startDate,
+    endDate: leave.endDate,
+    reason: leave.reason,
+  });
+  const createdLeave = await getLeaveById(newDoc._id);
+  if (!createdLeave) {
+    throw new Error("Failed to fetch the created leave");
+  }
+  return createdLeave;
+}
+
+export async function updateLeave(
+  id: string,
+  leave: Partial<LeaveInput>
+): Promise<Leave | null> {
+  const updatedDoc = await client.patch(id).set(leave).commit();
+  return getLeaveById(updatedDoc._id);
+}
+export async function deleteLeave(id: string): Promise<void> {
+  const deletedDoc = await client.delete(id);
+  if (!deletedDoc) {
+    throw new Error(`Failed to delete leave with id ${id}`);
+  }
+}

--- a/frontend/lib/sanity/utils/role.ts
+++ b/frontend/lib/sanity/utils/role.ts
@@ -1,0 +1,66 @@
+// import { Role } from "@/types/role";
+import { client } from "../client";
+
+export type Role = {
+  _id: string;
+  _createdAt: string;
+  _updatedAt: string;
+  title: string;
+  description: string;
+  permissions: string[];
+};
+
+export async function getAllRoles(): Promise<Role[]> {
+  const query = `*[_type == "role"]{
+    _id,
+    _createdAt,
+    _updatedAt,
+    title,
+    description,
+    permissions
+  } | order(title asc)`;
+
+  const results = await client.fetch(query);
+  return results as Role[];
+}
+
+export async function getRoleById(id: string): Promise<Role | null> {   
+  const query = `*[_type == "role" && _id == $id][0]{
+    _id,
+    _createdAt,
+    _updatedAt,
+    title,
+    description,
+    permissions
+  }`;
+
+  const role = await client.fetch(query, { id });
+  return role || null;
+}
+export async function createRole(role: Omit<Role, "_id" | "_createdAt" | "_updatedAt">): Promise<Role> {
+    const newDoc = await client.create({
+        _type: "role",
+        ...role,
+    });
+    
+    const populated = await getRoleById(newDoc._id);
+    return populated as Role;
+    }   
+
+export async function updateRole(id: string, role: Partial<Omit<Role, "_id" | "_createdAt" | "_updatedAt">>): Promise<Role | null> {
+    const updatedDoc = await client.patch(id).set(role).commit();
+
+    if (!updatedDoc) return null;
+
+    const populated = await getRoleById(updatedDoc._id);
+    return populated as Role;
+}
+export async function deleteRole(id: string): Promise<{ _id: string } | null> {
+  try {
+    const result = client.delete(id);
+    return result;
+  } catch (error) {
+    console.error("Error deleting department:", error);
+    return null;
+  }
+}

--- a/frontend/types/attendance.ts
+++ b/frontend/types/attendance.ts
@@ -11,3 +11,10 @@ export type Attendance = {
     email: string;
   };
 };
+
+export type AttendanceInput = {
+  employeeId: string;
+  date: string;
+  checkIn?: string | null;
+  checkOut?: string | null;
+};

--- a/frontend/types/department.ts
+++ b/frontend/types/department.ts
@@ -1,0 +1,7 @@
+export type Department = {
+  _id: string;
+  _createdAt: string;
+  _updatedAt: string;
+  name: string;
+  description: string;
+};

--- a/frontend/types/employee.ts
+++ b/frontend/types/employee.ts
@@ -7,12 +7,29 @@ export type Employee = {
   name: string;
   email: string;
   phone: string;
-  photo: Image | null; 
+  photo?: Image | "";
   employmentStatus: string;
   role: {
+    _id?: string;
     title: string;
   };
   startDate: string;
-  departmentName: string;
-  documents: File[];
+  department: {
+    _id?: string;
+    name: string;
+    description: string;
+  };
+  documents?: File[];
+};
+
+export type EmployeeInput = {
+  name: string;
+  email: string;
+  phone: string;
+  photo?: Image | "";
+  employmentStatus: string;
+  roleId: string;
+  departmentId: string;
+  startDate: string;
+  documents?: File[];
 };

--- a/frontend/types/leaves.ts
+++ b/frontend/types/leaves.ts
@@ -1,0 +1,23 @@
+export interface Leave {
+  _id: string;
+  _createdAt: string;
+  _updatedAt: string;
+  employee: {
+    _id: string;
+    name: string;
+    email: string;
+  };
+  type: "sick" | "vacation" | "wfh";
+  status: "pending" | "approved" | "rejected";
+  startDate: string;
+  endDate: string;
+  reason: string;
+}
+export interface LeaveInput {
+  employeeId: string;
+  type: "sick" | "vacation" | "wfh";
+  status: "pending" | "approved" | "rejected";
+  startDate: string;
+  endDate: string;
+  reason: string;
+}

--- a/frontend/types/role.ts
+++ b/frontend/types/role.ts
@@ -1,0 +1,8 @@
+export type Role = {
+  _id: string;
+  _createdAt: string;
+  _updatedAt: string;
+  title: string;
+  description: string;
+  permissions: string[];
+};


### PR DESCRIPTION
This PR integrates the Attendance and Leave management features by connecting the Sanity backend to the frontend UI.

 What’s Implemented:
Attendance

Fetch and display attendance records.

Create new attendance entries (with mock data for testing).

Delete attendance records.

Leave

Fetch and display leave requests.

Create and delete leave requests (optional based on current scope)